### PR TITLE
fix: 当 from 与 to 相同时可以让安装继续

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -16,11 +16,19 @@ function install () {
   debug(`cwd: ${cwd}`)
   debug(`root: ${root}`)
 
+  const rootName = path.basename(root)
+
+  // 在 preset 开发时跳过安装过程
+  if (/^elint-preset-.*/.test(rootName)) {
+    console.log(`  find elint preset directory: ${rootName}, skip preset installation`)
+    return
+  }
+
   linterConfigFile.forEach(fileName => {
     const from = path.join(cwd, fileName)
     const to = path.join(root, fileName)
 
-    if (!fs.pathExistsSync(from) || from === to) {
+    if (!fs.pathExistsSync(from)) {
       return
     }
 

--- a/src/install.js
+++ b/src/install.js
@@ -20,7 +20,7 @@ function install () {
     const from = path.join(cwd, fileName)
     const to = path.join(root, fileName)
 
-    if (!fs.pathExistsSync(from)) {
+    if (!fs.pathExistsSync(from) || from === to) {
       return
     }
 


### PR DESCRIPTION
在 preset 项目中安装依赖时，会触发 postinstall 钩子导致 elint-helpers install 被执行，而此时的 from 和 to 是相同的，因此会导致复制操作报错